### PR TITLE
fix: bump builder image to golang 1.26.5 to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY frontend/ ./
 RUN pnpm build
 
 # Backend build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS build
 ARG TARGETOS
 ARG TARGETARCH
 ADD ./ ./


### PR DESCRIPTION
## Summary
- `go.mod` requires `go 1.26.5` but the Dockerfile builder stage was pinned to `golang:1.26.4-alpine3.22`, breaking the v4.4.0 release build with `go: go.mod requires go >= 1.26.5`.
- Same issue as note-tweet-connector#133 — unrelated to the Helm chart OCI migration in #335, but blocked the release needed to complete it.
- `golang:1.26.5-alpine3.22` doesn't exist upstream, so this also moves to the `alpine3.23` variant.

## Test plan
- [ ] docker build succeeds on this PR
- [ ] release build (build/merge/chart) succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)