### PR TITLE
fix: pin pnpm version in Dockerfile to match packageManager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Frontend build stage
 FROM node:25.9.0-alpine3.23 AS frontend-build
 WORKDIR /app/frontend
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.33.4
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY frontend/ ./


### PR DESCRIPTION
## Summary
- The frontend build stage installs pnpm via a bare `npm install -g pnpm`, ignoring `frontend/package.json`'s pinned `"packageManager": "pnpm@10.33.4"`.
- A newer pnpm release enforces a native-binary integrity check the existing lockfile doesn't satisfy, breaking `pnpm install --frozen-lockfile` on arm64 with `Cannot verify the identity of the @pnpm/exe.linux-arm64 native binary: it is missing from pnpm-lock.yaml`.
- **This has silently broken every release build since v4.3.1 (2026-08-01)** — found while chasing an unrelated release failure for the Helm chart OCI migration (#335), not caused by it.
- Fix: pin the install to the declared version.

## Test plan
- [ ] docker build succeeds on this PR
- [ ] release build (build/merge/chart) succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)