### PR TITLE
fix(twitter): 投稿前にアクセストークンを更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ spotify-nowplaying/
 │   │   ├── spotify_auth.go  # Spotify OAuth（フロントエンド用）
 │   │   ├── miauth.go        # MiAuth フロー
 │   │   ├── twitter_auth.go  # Twitter OAuth 2.0 PKCE
-│   │   ├── api_post.go      # API 直接投稿
+│   │   ├── api_post.go      # API 直接投稿（トークン更新・再試行を含む）
 │   │   └── settings.go      # ユーザー設定
 │   ├── metrics/             # Prometheusメトリクス
 │   │   ├── metrics.go
@@ -86,6 +86,9 @@ spotify-nowplaying/
 │   │   ├── client_test.go   # クライアントテスト
 │   │   ├── player.go        # 再生情報取得・シェアURL生成
 │   │   └── player_test.go   # プレイヤーテスト
+│   ├── twitter/             # Twitter API関連
+│   │   ├── client.go        # トークン更新・ツイート投稿クライアント
+│   │   └── client_test.go   # クライアントテスト
 │   └── store/               # データベース
 │       └── store.go         # PostgreSQL 操作
 ├── migrations/              # DBマイグレーション
@@ -318,6 +321,19 @@ curl "https://example.tld/api/post/your-api-token?target=misskey"
 # 両方に投稿（ヘッダートークン認証あり）
 curl -H "X-API-Token: your-header-token" "https://example.tld/api/post/your-api-token"
 ```
+
+#### レスポンス
+
+投稿先ごとの結果は `results` に入ります。
+
+| ステータス | 意味 |
+|---|---|
+| `200` | 少なくとも1つの投稿先へ投稿できた（再生中の曲がない場合も200） |
+| `502` | 投稿を試みたすべての投稿先が失敗した |
+
+Twitterのアクセストークンは約2時間で失効するため、投稿前に必要に応じてリフレッシュトークンで自動更新します。
+再連携が必要な状態（リフレッシュトークンが失効・失効済み）の場合は、`results.twitter` が `error: twitter token expired, reconnect required` になります。
+ダッシュボードからTwitterを再連携してください。
 
 ## メトリクス
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Soli0222/spotify-nowplaying/internal/metrics"
 	"github.com/Soli0222/spotify-nowplaying/internal/spotify"
 	"github.com/Soli0222/spotify-nowplaying/internal/store"
+	"github.com/Soli0222/spotify-nowplaying/internal/twitter"
 
 	"github.com/joho/godotenv"
 	"github.com/labstack/echo/v4"
@@ -99,6 +100,7 @@ func main() {
 
 	// SpotifyクライアントとHandlerを初期化
 	spotifyClient := spotify.NewHTTPClient()
+	twitterClient := twitter.NewHTTPClient()
 	h := handler.NewHandler(spotifyClient)
 
 	// Construct DATABASE_URL from POSTGRES_* env vars if not explicitly set
@@ -152,9 +154,9 @@ func main() {
 		// API handlers
 		spotifyAuthHandler := handler.NewSpotifyAuthHandler(db, spotifyClient, jwtConfig)
 		miAuthHandler := handler.NewMiAuthHandler(db, jwtConfig)
-		twitterAuthHandler := handler.NewTwitterAuthHandler(db, jwtConfig)
+		twitterAuthHandler := handler.NewTwitterAuthHandler(db, twitterClient, jwtConfig)
 		settingsHandler := handler.NewSettingsHandler(db, jwtConfig)
-		apiPostHandler := handler.NewAPIPostHandler(db, spotifyClient)
+		apiPostHandler := handler.NewAPIPostHandler(db, spotifyClient, twitterClient)
 
 		// API routes
 		api := e.Group("/api")

--- a/internal/handler/api_post.go
+++ b/internal/handler/api_post.go
@@ -2,7 +2,9 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"github.com/Soli0222/spotify-nowplaying/internal/auth"
 	"github.com/Soli0222/spotify-nowplaying/internal/spotify"
 	"github.com/Soli0222/spotify-nowplaying/internal/store"
+	"github.com/Soli0222/spotify-nowplaying/internal/twitter"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
@@ -20,14 +23,30 @@ import (
 type APIPostHandler struct {
 	store         *store.Store
 	spotifyClient spotify.Client
+	twitterClient twitter.Client
 }
 
 // NewAPIPostHandler creates a new APIPostHandler
-func NewAPIPostHandler(s *store.Store, client spotify.Client) *APIPostHandler {
+func NewAPIPostHandler(s *store.Store, client spotify.Client, twitterClient twitter.Client) *APIPostHandler {
 	return &APIPostHandler{
 		store:         s,
 		spotifyClient: client,
+		twitterClient: twitterClient,
 	}
+}
+
+// twitterTokenLeeway is how long before the recorded expiry the Twitter access
+// token is refreshed. Twitter access tokens are valid for two hours.
+const twitterTokenLeeway = 5 * time.Minute
+
+// twitterTokenNeedsRefresh reports whether the access token expiring at
+// expiresAt should be refreshed before use. An unknown expiry (zero value, e.g.
+// a row written before expiries were stored) is treated as expired.
+func twitterTokenNeedsRefresh(expiresAt time.Time, now time.Time) bool {
+	if expiresAt.IsZero() {
+		return true
+	}
+	return !now.Add(twitterTokenLeeway).Before(expiresAt)
 }
 
 // PostTarget represents the target platform for posting
@@ -51,11 +70,6 @@ type MisskeyNoteRequest struct {
 	I          string `json:"i"`
 	Text       string `json:"text"`
 	Visibility string `json:"visibility,omitempty"`
-}
-
-// TwitterTweetRequest represents the request body for creating a Twitter tweet
-type TwitterTweetRequest struct {
-	Text string `json:"text"`
 }
 
 // PostNowPlaying posts the currently playing track to configured platforms
@@ -173,15 +187,19 @@ func (h *APIPostHandler) PostNowPlaying(c echo.Context) error {
 	}
 
 	results := make(map[string]string)
+	attempted := 0
+	succeeded := 0
 
 	// Post to Misskey
 	if target == PostTargetMisskey || target == PostTargetBoth {
 		if user.MisskeyAccessToken.Valid && user.MisskeyAccessToken.String != "" {
+			attempted++
 			err := h.postToMisskey(user.MisskeyInstanceURL.String, user.MisskeyAccessToken.String, postText)
 			if err != nil {
 				results["misskey"] = fmt.Sprintf("error: %s", err.Error())
 			} else {
 				results["misskey"] = "success"
+				succeeded++
 			}
 		} else {
 			results["misskey"] = "not connected"
@@ -191,28 +209,33 @@ func (h *APIPostHandler) PostNowPlaying(c echo.Context) error {
 	// Post to Twitter
 	if target == PostTargetTwitter || target == PostTargetBoth {
 		if user.TwitterAccessToken.Valid && user.TwitterAccessToken.String != "" {
-			err := h.postToTwitter(user.TwitterAccessToken.String, postText)
-			if err != nil {
-				results["twitter"] = fmt.Sprintf("error: %s", err.Error())
-			} else {
+			attempted++
+			err := h.postToTwitter(ctx, user.ID, postText)
+			switch {
+			case err == nil:
 				results["twitter"] = "success"
+				succeeded++
+			case errors.Is(err, twitter.ErrReauthRequired):
+				results["twitter"] = "error: twitter token expired, reconnect required"
+			case errors.Is(err, store.ErrTwitterNotConnected):
+				results["twitter"] = "not connected"
+			default:
+				results["twitter"] = fmt.Sprintf("error: %s", err.Error())
 			}
 		} else {
 			results["twitter"] = "not connected"
 		}
 	}
 
-	// Check if any succeeded
-	anySuccess := false
-	for _, v := range results {
-		if v == "success" {
-			anySuccess = true
-			break
-		}
+	// Every platform we actually tried to post to failed: report it as an error
+	// so callers and monitoring do not read a 200 as a successful post.
+	status := http.StatusOK
+	if attempted > 0 && succeeded == 0 {
+		status = http.StatusBadGateway
 	}
 
-	return c.JSON(http.StatusOK, PostResponse{
-		Success: anySuccess,
+	return c.JSON(status, PostResponse{
+		Success: succeeded > 0,
 		Message: postText,
 		Results: results,
 	})
@@ -264,36 +287,74 @@ func (h *APIPostHandler) postToMisskey(instanceURL, accessToken, text string) er
 	return nil
 }
 
-// postToTwitter posts a tweet to Twitter
-func (h *APIPostHandler) postToTwitter(accessToken, text string) error {
-	reqBody := TwitterTweetRequest{
-		Text: text,
-	}
+// twitterTokenStore is the part of the store postTweetWithRefresh needs.
+// *store.Store implements it.
+type twitterTokenStore interface {
+	EnsureTwitterToken(ctx context.Context, userID uuid.UUID, refresh func(context.Context, store.TwitterTokens) (*store.TwitterTokens, error)) (store.TwitterTokens, error)
+}
 
-	jsonBody, err := json.Marshal(reqBody)
+// twitterPostTimeout bounds a single post, including up to two refreshes.
+const twitterPostTimeout = 60 * time.Second
+
+// postToTwitter posts a tweet as the given user.
+func (h *APIPostHandler) postToTwitter(ctx context.Context, userID uuid.UUID, text string) error {
+	// Detach from the request: if the caller hangs up mid-refresh, the rotated
+	// refresh token must still be written, otherwise the account is left with a
+	// refresh token Twitter has already invalidated.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), twitterPostTimeout)
+	defer cancel()
+
+	return postTweetWithRefresh(ctx, h.store, h.twitterClient, userID, text)
+}
+
+// postTweetWithRefresh posts a tweet, refreshing the stored access token before
+// posting when it is expired (or about to be), and once more if Twitter answers
+// 401 anyway. Refreshes run under the store's per-user lock, so concurrent posts
+// cannot invalidate each other's rotated refresh token.
+func postTweetWithRefresh(ctx context.Context, tokenStore twitterTokenStore, client twitter.Client, userID uuid.UUID, text string) error {
+	tokens, err := tokenStore.EnsureTwitterToken(ctx, userID, func(ctx context.Context, current store.TwitterTokens) (*store.TwitterTokens, error) {
+		if !twitterTokenNeedsRefresh(current.ExpiresAt, time.Now()) {
+			return nil, nil
+		}
+		return refreshTwitterTokens(ctx, client, current.RefreshToken)
+	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal request: %w", err)
+		return err
 	}
 
-	req, err := http.NewRequest("POST", "https://api.twitter.com/2/tweets", bytes.NewBuffer(jsonBody))
+	postErr := client.PostTweet(ctx, tokens.AccessToken, text)
+	if apiErr, ok := twitter.IsAPIError(postErr); !ok || apiErr.StatusCode != http.StatusUnauthorized {
+		return postErr
+	}
+
+	// The token was rejected even though it still looked valid (clock skew, a
+	// token revoked on Twitter's side, ...). Refresh once and retry.
+	rejected := tokens.AccessToken
+	tokens, err = tokenStore.EnsureTwitterToken(ctx, userID, func(ctx context.Context, current store.TwitterTokens) (*store.TwitterTokens, error) {
+		if current.AccessToken != rejected {
+			// A concurrent post already refreshed it; use what it stored.
+			return nil, nil
+		}
+		return refreshTwitterTokens(ctx, client, current.RefreshToken)
+	})
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+accessToken)
+	return client.PostTweet(ctx, tokens.AccessToken, text)
+}
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+// refreshTwitterTokens exchanges the refresh token for a new set of tokens.
+// Twitter rotates the refresh token, so all three values have to be stored.
+func refreshTwitterTokens(ctx context.Context, client twitter.Client, refreshToken string) (*store.TwitterTokens, error) {
+	tokens, err := client.RefreshToken(ctx, refreshToken)
 	if err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("twitter api error: %d - %s", resp.StatusCode, string(body))
+		return nil, err
 	}
 
-	return nil
+	return &store.TwitterTokens{
+		AccessToken:  tokens.AccessToken,
+		RefreshToken: tokens.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(tokens.ExpiresIn) * time.Second),
+	}, nil
 }

--- a/internal/handler/api_post_twitter_test.go
+++ b/internal/handler/api_post_twitter_test.go
@@ -1,0 +1,256 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Soli0222/spotify-nowplaying/internal/store"
+	"github.com/Soli0222/spotify-nowplaying/internal/twitter"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTwitterTokenStore keeps the tokens in memory, mimicking the locked
+// read-modify-write the real store performs.
+type fakeTwitterTokenStore struct {
+	tokens store.TwitterTokens
+	// beforeRefresh runs while the "lock" is held, to simulate another request
+	// having refreshed the tokens in the meantime.
+	beforeRefresh func(s *fakeTwitterTokenStore)
+	writes        int
+	err           error
+}
+
+func (s *fakeTwitterTokenStore) EnsureTwitterToken(ctx context.Context, userID uuid.UUID, refresh func(context.Context, store.TwitterTokens) (*store.TwitterTokens, error)) (store.TwitterTokens, error) {
+	if s.err != nil {
+		return store.TwitterTokens{}, s.err
+	}
+	if s.beforeRefresh != nil {
+		s.beforeRefresh(s)
+	}
+
+	updated, err := refresh(ctx, s.tokens)
+	if err != nil {
+		return store.TwitterTokens{}, err
+	}
+	if updated != nil {
+		s.tokens = *updated
+		s.writes++
+	}
+	return s.tokens, nil
+}
+
+type fakeTwitterClient struct {
+	postedTokens  []string
+	postErrs      []error
+	refreshCalls  []string
+	refreshTokens *twitter.Tokens
+	refreshErr    error
+}
+
+func (c *fakeTwitterClient) ExchangeToken(ctx context.Context, code, redirectURI, codeVerifier string) (*twitter.Tokens, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *fakeTwitterClient) GetUserInfo(ctx context.Context, accessToken string) (*twitter.UserInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *fakeTwitterClient) RefreshToken(ctx context.Context, refreshToken string) (*twitter.Tokens, error) {
+	c.refreshCalls = append(c.refreshCalls, refreshToken)
+	if c.refreshErr != nil {
+		return nil, c.refreshErr
+	}
+	return c.refreshTokens, nil
+}
+
+func (c *fakeTwitterClient) PostTweet(ctx context.Context, accessToken, text string) error {
+	c.postedTokens = append(c.postedTokens, accessToken)
+	if len(c.postErrs) == 0 {
+		return nil
+	}
+	err := c.postErrs[0]
+	c.postErrs = c.postErrs[1:]
+	return err
+}
+
+func TestTwitterTokenNeedsRefresh(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{"valid for another hour", now.Add(time.Hour), false},
+		{"valid beyond the leeway", now.Add(twitterTokenLeeway + time.Minute), false},
+		{"inside the leeway", now.Add(twitterTokenLeeway - time.Minute), true},
+		{"already expired", now.Add(-time.Minute), true},
+		{"expiry unknown", time.Time{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, twitterTokenNeedsRefresh(tt.expiresAt, now))
+		})
+	}
+}
+
+func TestPostTweetWithRefresh_ValidTokenIsUsedAsIs(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}}
+	c := &fakeTwitterClient{}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"access"}, c.postedTokens)
+	assert.Empty(t, c.refreshCalls)
+	assert.Zero(t, s.writes)
+}
+
+func TestPostTweetWithRefresh_ExpiredTokenIsRefreshedAndStored(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "expired",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	}}
+	c := &fakeTwitterClient{refreshTokens: &twitter.Tokens{
+		AccessToken:  "fresh",
+		RefreshToken: "rotated",
+		ExpiresIn:    7200,
+	}}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"refresh"}, c.refreshCalls)
+	assert.Equal(t, []string{"fresh"}, c.postedTokens)
+	assert.Equal(t, 1, s.writes)
+	assert.Equal(t, "fresh", s.tokens.AccessToken)
+	assert.Equal(t, "rotated", s.tokens.RefreshToken)
+	assert.True(t, s.tokens.ExpiresAt.After(time.Now().Add(time.Hour)))
+}
+
+func TestPostTweetWithRefresh_RetriesOnceOn401(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "stale",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Add(time.Hour), // looks valid, Twitter disagrees
+	}}
+	c := &fakeTwitterClient{
+		postErrs:      []error{&twitter.APIError{StatusCode: http.StatusUnauthorized}},
+		refreshTokens: &twitter.Tokens{AccessToken: "fresh", RefreshToken: "rotated", ExpiresIn: 7200},
+	}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stale", "fresh"}, c.postedTokens)
+	assert.Equal(t, 1, len(c.refreshCalls))
+}
+
+func TestPostTweetWithRefresh_DoesNotRetryTwice(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "stale",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}}
+	unauthorized := &twitter.APIError{StatusCode: http.StatusUnauthorized}
+	c := &fakeTwitterClient{
+		postErrs:      []error{unauthorized, unauthorized},
+		refreshTokens: &twitter.Tokens{AccessToken: "fresh", RefreshToken: "rotated", ExpiresIn: 7200},
+	}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	require.Error(t, err)
+	apiErr, ok := twitter.IsAPIError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.Len(t, c.postedTokens, 2)
+	assert.Len(t, c.refreshCalls, 1)
+}
+
+func TestPostTweetWithRefresh_SkipsRefreshWhenAnotherRequestAlreadyDidIt(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "stale",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}}
+	c := &fakeTwitterClient{postErrs: []error{&twitter.APIError{StatusCode: http.StatusUnauthorized}}}
+
+	// After the 401, a concurrent post has already refreshed the tokens.
+	firstCall := true
+	s.beforeRefresh = func(s *fakeTwitterTokenStore) {
+		if firstCall {
+			firstCall = false
+			return
+		}
+		s.tokens = store.TwitterTokens{
+			AccessToken:  "refreshed-elsewhere",
+			RefreshToken: "rotated",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		}
+	}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	require.NoError(t, err)
+	assert.Empty(t, c.refreshCalls)
+	assert.Equal(t, []string{"stale", "refreshed-elsewhere"}, c.postedTokens)
+}
+
+func TestPostTweetWithRefresh_ReauthRequiredIsPropagated(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "expired",
+		RefreshToken: "revoked",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	}}
+	c := &fakeTwitterClient{refreshErr: fmt.Errorf("%w: invalid_grant", twitter.ErrReauthRequired)}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	assert.ErrorIs(t, err, twitter.ErrReauthRequired)
+	assert.Empty(t, c.postedTokens)
+	assert.Zero(t, s.writes)
+}
+
+func TestPostTweetWithRefresh_NotConnected(t *testing.T) {
+	s := &fakeTwitterTokenStore{err: store.ErrTwitterNotConnected}
+	c := &fakeTwitterClient{}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	assert.ErrorIs(t, err, store.ErrTwitterNotConnected)
+	assert.Empty(t, c.postedTokens)
+}
+
+func TestPostTweetWithRefresh_OtherAPIErrorIsNotRetried(t *testing.T) {
+	s := &fakeTwitterTokenStore{tokens: store.TwitterTokens{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}}
+	c := &fakeTwitterClient{postErrs: []error{&twitter.APIError{StatusCode: http.StatusTooManyRequests}}}
+
+	err := postTweetWithRefresh(context.Background(), s, c, uuid.New(), "now playing")
+
+	require.Error(t, err)
+	apiErr, ok := twitter.IsAPIError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode)
+	assert.Len(t, c.postedTokens, 1)
+	assert.Empty(t, c.refreshCalls)
+}
+
+// *store.Store must satisfy the interface postTweetWithRefresh depends on.
+var _ twitterTokenStore = (*store.Store)(nil)

--- a/internal/handler/twitter_auth.go
+++ b/internal/handler/twitter_auth.go
@@ -1,41 +1,32 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/Soli0222/spotify-nowplaying/internal/auth"
 	"github.com/Soli0222/spotify-nowplaying/internal/store"
+	"github.com/Soli0222/spotify-nowplaying/internal/twitter"
 	"github.com/labstack/echo/v4"
 )
 
 // TwitterAuthHandler handles Twitter OAuth 2.0 PKCE authentication
 type TwitterAuthHandler struct {
-	store     *store.Store
-	jwtConfig auth.JWTConfig
+	store         *store.Store
+	twitterClient twitter.Client
+	jwtConfig     auth.JWTConfig
 }
 
 // NewTwitterAuthHandler creates a new TwitterAuthHandler
-func NewTwitterAuthHandler(s *store.Store, jwtConfig auth.JWTConfig) *TwitterAuthHandler {
+func NewTwitterAuthHandler(s *store.Store, twitterClient twitter.Client, jwtConfig auth.JWTConfig) *TwitterAuthHandler {
 	return &TwitterAuthHandler{
-		store:     s,
-		jwtConfig: jwtConfig,
+		store:         s,
+		twitterClient: twitterClient,
+		jwtConfig:     jwtConfig,
 	}
-}
-
-// TwitterTokenResponse is the response from Twitter token endpoint
-type TwitterTokenResponse struct {
-	TokenType    string `json:"token_type"`
-	ExpiresIn    int    `json:"expires_in"`
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	Scope        string `json:"scope"`
 }
 
 // StartTwitterAuth starts the Twitter OAuth 2.0 PKCE flow
@@ -132,57 +123,24 @@ func (h *TwitterAuthHandler) CallbackTwitterAuth(c echo.Context) error {
 	}
 
 	// Exchange code for tokens
-	clientID := os.Getenv("TWITTER_CLIENT_ID")
-	clientSecret := os.Getenv("TWITTER_CLIENT_SECRET")
 	redirectURI := os.Getenv("BASE_URL") + "/api/twitter/callback"
-
-	data := url.Values{}
-	data.Set("code", code)
-	data.Set("grant_type", "authorization_code")
-	data.Set("redirect_uri", redirectURI)
-	data.Set("code_verifier", session.CodeVerifier)
-
-	req, err := http.NewRequest("POST", "https://api.twitter.com/2/oauth2/token", strings.NewReader(data.Encode()))
+	tokens, err := h.twitterClient.ExchangeToken(ctx, code, redirectURI, session.CodeVerifier)
 	if err != nil {
-		return c.Redirect(http.StatusFound, "/dashboard?error=request_failed")
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(clientID, clientSecret)
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return c.Redirect(http.StatusFound, "/dashboard?error=exchange_failed")
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return c.Redirect(http.StatusFound, "/dashboard?error=read_failed")
-	}
-
-	if resp.StatusCode != http.StatusOK {
 		return c.Redirect(http.StatusFound, "/dashboard?error=token_failed")
 	}
 
-	var tokenResp TwitterTokenResponse
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return c.Redirect(http.StatusFound, "/dashboard?error=parse_failed")
-	}
-
 	// Calculate expiration time
-	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	expiresAt := time.Now().Add(time.Duration(tokens.ExpiresIn) * time.Second)
 
 	// Fetch Twitter user info
-	twitterUser, err := h.getTwitterUserInfo(tokenResp.AccessToken)
+	twitterUser, err := h.twitterClient.GetUserInfo(ctx, tokens.AccessToken)
 	if err != nil {
 		// If we can't get user info, still save the token but with empty user info
-		twitterUser = &TwitterUserInfo{}
+		twitterUser = &twitter.UserInfo{}
 	}
 
 	// Save the token and user info to user
-	if err := h.store.UpdateTwitterToken(ctx, session.UserID, tokenResp.AccessToken, tokenResp.RefreshToken, expiresAt, twitterUser.ID, twitterUser.Username, twitterUser.ProfileImageURL); err != nil {
+	if err := h.store.UpdateTwitterToken(ctx, session.UserID, tokens.AccessToken, tokens.RefreshToken, expiresAt, twitterUser.ID, twitterUser.Username, twitterUser.ProfileImageURL); err != nil {
 		return c.Redirect(http.StatusFound, "/dashboard?error=save_failed")
 	}
 
@@ -190,47 +148,6 @@ func (h *TwitterAuthHandler) CallbackTwitterAuth(c echo.Context) error {
 	_ = h.store.DeleteTwitterPKCESession(ctx, state)
 
 	return c.Redirect(http.StatusFound, "/dashboard?success=twitter_connected")
-}
-
-// RefreshTwitterToken refreshes the Twitter access token
-func (h *TwitterAuthHandler) RefreshTwitterToken(ctx echo.Context, userID string, refreshToken string) (*TwitterTokenResponse, error) {
-	clientID := os.Getenv("TWITTER_CLIENT_ID")
-	clientSecret := os.Getenv("TWITTER_CLIENT_SECRET")
-
-	data := url.Values{}
-	data.Set("refresh_token", refreshToken)
-	data.Set("grant_type", "refresh_token")
-
-	req, err := http.NewRequest("POST", "https://api.twitter.com/2/oauth2/token", strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(clientID, clientSecret)
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("refresh failed: %s", string(body))
-	}
-
-	var tokenResp TwitterTokenResponse
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, err
-	}
-
-	return &tokenResp, nil
 }
 
 // DisconnectTwitter disconnects Twitter from the user account
@@ -247,51 +164,4 @@ func (h *TwitterAuthHandler) DisconnectTwitter(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "twitter disconnected"})
-}
-
-// TwitterUserInfo represents Twitter user information
-type TwitterUserInfo struct {
-	ID              string `json:"id"`
-	Name            string `json:"name"`
-	Username        string `json:"username"`
-	ProfileImageURL string `json:"profile_image_url"`
-}
-
-// TwitterUserResponse represents the response from Twitter users/me endpoint
-type TwitterUserResponse struct {
-	Data TwitterUserInfo `json:"data"`
-}
-
-// getTwitterUserInfo fetches the Twitter user information
-func (h *TwitterAuthHandler) getTwitterUserInfo(accessToken string) (*TwitterUserInfo, error) {
-	req, err := http.NewRequest("GET", "https://api.twitter.com/2/users/me?user.fields=profile_image_url", nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("twitter api error: %d - %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var userResp TwitterUserResponse
-	if err := json.Unmarshal(body, &userResp); err != nil {
-		return nil, err
-	}
-
-	return &userResp.Data, nil
 }

--- a/internal/handler/types_test.go
+++ b/internal/handler/types_test.go
@@ -54,21 +54,6 @@ func TestMisskeyNoteRequest_JSONMarshal(t *testing.T) {
 	assert.Equal(t, "public", unmarshaled["visibility"])
 }
 
-func TestTwitterTweetRequest_JSONMarshal(t *testing.T) {
-	req := TwitterTweetRequest{
-		Text: "Hello Twitter",
-	}
-
-	data, err := json.Marshal(req)
-	assert.NoError(t, err)
-
-	var unmarshaled map[string]string
-	err = json.Unmarshal(data, &unmarshaled)
-	assert.NoError(t, err)
-
-	assert.Equal(t, "Hello Twitter", unmarshaled["text"])
-}
-
 func TestUserInfoResponse_JSONMarshal(t *testing.T) {
 	resp := UserInfoResponse{
 		ID:                    "user-123",

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -327,6 +328,106 @@ func (s *Store) UpdateTwitterToken(ctx context.Context, userID uuid.UUID, access
 		return fmt.Errorf("failed to update twitter token: %w", err)
 	}
 	return nil
+}
+
+// TwitterTokens holds the Twitter OAuth tokens stored for a user.
+type TwitterTokens struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+// ErrTwitterNotConnected is returned when the user has no Twitter access token stored.
+var ErrTwitterNotConnected = errors.New("twitter is not connected")
+
+// EnsureTwitterToken hands the currently stored Twitter tokens to refresh and
+// persists whatever it returns. The user row is locked for the duration, so
+// concurrent posts for the same user cannot refresh at the same time and race
+// each other into invalidating the rotated refresh token; refresh therefore
+// always sees the tokens the previous caller has just written.
+//
+// refresh may return (nil, nil) to signal that the stored tokens are still good,
+// in which case nothing is written.
+func (s *Store) EnsureTwitterToken(ctx context.Context, userID uuid.UUID, refresh func(ctx context.Context, current TwitterTokens) (*TwitterTokens, error)) (TwitterTokens, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return TwitterTokens{}, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		accessToken  sql.NullString
+		refreshToken sql.NullString
+		expiresAt    sql.NullTime
+	)
+	err = tx.QueryRowContext(ctx, `
+		SELECT twitter_access_token, twitter_refresh_token, twitter_token_expires_at
+		FROM users
+		WHERE id = $1
+		FOR UPDATE
+	`, userID).Scan(&accessToken, &refreshToken, &expiresAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return TwitterTokens{}, ErrTwitterNotConnected
+		}
+		return TwitterTokens{}, fmt.Errorf("failed to lock twitter token: %w", err)
+	}
+
+	if !accessToken.Valid || accessToken.String == "" {
+		return TwitterTokens{}, ErrTwitterNotConnected
+	}
+
+	current := TwitterTokens{}
+	current.AccessToken, err = crypto.DecryptToken(accessToken.String)
+	if err != nil {
+		return TwitterTokens{}, fmt.Errorf("failed to decrypt twitter access token: %w", err)
+	}
+	if refreshToken.Valid && refreshToken.String != "" {
+		current.RefreshToken, err = crypto.DecryptToken(refreshToken.String)
+		if err != nil {
+			return TwitterTokens{}, fmt.Errorf("failed to decrypt twitter refresh token: %w", err)
+		}
+	}
+	if expiresAt.Valid {
+		current.ExpiresAt = expiresAt.Time
+	}
+
+	updated, err := refresh(ctx, current)
+	if err != nil {
+		return TwitterTokens{}, err
+	}
+	if updated == nil {
+		if err := tx.Commit(); err != nil {
+			return TwitterTokens{}, fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		return current, nil
+	}
+
+	encAccessToken, err := crypto.EncryptToken(updated.AccessToken)
+	if err != nil {
+		return TwitterTokens{}, fmt.Errorf("failed to encrypt twitter access token: %w", err)
+	}
+	encRefreshToken, err := crypto.EncryptToken(updated.RefreshToken)
+	if err != nil {
+		return TwitterTokens{}, fmt.Errorf("failed to encrypt twitter refresh token: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE users SET
+			twitter_access_token = $2,
+			twitter_refresh_token = $3,
+			twitter_token_expires_at = $4,
+			updated_at = NOW()
+		WHERE id = $1
+	`, userID, encAccessToken, encRefreshToken, updated.ExpiresAt); err != nil {
+		return TwitterTokens{}, fmt.Errorf("failed to update twitter token: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return TwitterTokens{}, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return *updated, nil
 }
 
 // UpdateSpotifyToken updates the Spotify token for a user

--- a/internal/twitter/client.go
+++ b/internal/twitter/client.go
@@ -39,6 +39,12 @@ type userResponse struct {
 	Data UserInfo `json:"data"`
 }
 
+// oauthError is the error response of the token endpoint (RFC 6749 5.2).
+type oauthError struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description"`
+}
+
 // ErrReauthRequired is returned when the stored refresh token can no longer be
 // used, so the user has to connect their Twitter account again.
 var ErrReauthRequired = errors.New("twitter reauthorization required")
@@ -179,10 +185,12 @@ func (c *HTTPClient) requestTokens(ctx context.Context, form url.Values, operati
 	if resp.StatusCode != http.StatusOK {
 		c.logger.Error(operation+" failed", "status", resp.StatusCode, "body", string(body))
 		apiErr := &APIError{StatusCode: resp.StatusCode, Message: string(body)}
-		// The grant itself was rejected: refreshing again will not help.
-		if resp.StatusCode == http.StatusBadRequest ||
-			resp.StatusCode == http.StatusUnauthorized ||
-			resp.StatusCode == http.StatusForbidden {
+		// RFC 6749 5.2: only invalid_grant means the grant itself is dead and the
+		// user has to authorize again. invalid_client, invalid_request and
+		// unauthorized_client come back with the same status but point at this
+		// application's configuration, where reconnecting would not help.
+		var oauthErr oauthError
+		if err := json.Unmarshal(body, &oauthErr); err == nil && oauthErr.Code == "invalid_grant" {
 			return nil, fmt.Errorf("%w: %v", ErrReauthRequired, apiErr)
 		}
 		return nil, apiErr

--- a/internal/twitter/client.go
+++ b/internal/twitter/client.go
@@ -1,0 +1,280 @@
+// Package twitter provides a small client for the parts of the X (Twitter) API
+// this application uses: the OAuth 2.0 PKCE token endpoint, users/me and tweet
+// creation.
+package twitter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Tokens is the response from the Twitter token endpoint.
+type Tokens struct {
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+// UserInfo represents Twitter user information.
+type UserInfo struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Username        string `json:"username"`
+	ProfileImageURL string `json:"profile_image_url"`
+}
+
+type userResponse struct {
+	Data UserInfo `json:"data"`
+}
+
+// ErrReauthRequired is returned when the stored refresh token can no longer be
+// used, so the user has to connect their Twitter account again.
+var ErrReauthRequired = errors.New("twitter reauthorization required")
+
+// Client is the interface of the Twitter API client.
+type Client interface {
+	// ExchangeToken exchanges an authorization code for tokens.
+	ExchangeToken(ctx context.Context, code, redirectURI, codeVerifier string) (*Tokens, error)
+	// RefreshToken exchanges a refresh token for a new set of tokens.
+	RefreshToken(ctx context.Context, refreshToken string) (*Tokens, error)
+	// GetUserInfo fetches the profile of the authenticated user.
+	GetUserInfo(ctx context.Context, accessToken string) (*UserInfo, error)
+	// PostTweet posts a tweet as the authenticated user.
+	PostTweet(ctx context.Context, accessToken, text string) error
+}
+
+// HTTPClient talks to the real Twitter API.
+type HTTPClient struct {
+	client       *http.Client
+	tokenURL     string
+	tweetURL     string
+	userURL      string
+	clientID     string
+	clientSecret string
+	logger       *slog.Logger
+}
+
+// ClientOption configures an HTTPClient.
+type ClientOption func(*HTTPClient)
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *HTTPClient) { c.client = client }
+}
+
+// WithTokenURL overrides the token endpoint (for tests).
+func WithTokenURL(u string) ClientOption {
+	return func(c *HTTPClient) { c.tokenURL = u }
+}
+
+// WithTweetURL overrides the tweet endpoint (for tests).
+func WithTweetURL(u string) ClientOption {
+	return func(c *HTTPClient) { c.tweetURL = u }
+}
+
+// WithUserURL overrides the users/me endpoint (for tests).
+func WithUserURL(u string) ClientOption {
+	return func(c *HTTPClient) { c.userURL = u }
+}
+
+// WithCredentials overrides the OAuth client credentials (for tests).
+func WithCredentials(clientID, clientSecret string) ClientOption {
+	return func(c *HTTPClient) {
+		c.clientID = clientID
+		c.clientSecret = clientSecret
+	}
+}
+
+// WithLogger sets the logger.
+func WithLogger(logger *slog.Logger) ClientOption {
+	return func(c *HTTPClient) { c.logger = logger }
+}
+
+// NewHTTPClient creates a new HTTPClient.
+func NewHTTPClient(opts ...ClientOption) *HTTPClient {
+	c := &HTTPClient{
+		client:       &http.Client{Timeout: 30 * time.Second},
+		tokenURL:     "https://api.twitter.com/2/oauth2/token",
+		tweetURL:     "https://api.twitter.com/2/tweets",
+		userURL:      "https://api.twitter.com/2/users/me?user.fields=profile_image_url",
+		clientID:     os.Getenv("TWITTER_CLIENT_ID"),
+		clientSecret: os.Getenv("TWITTER_CLIENT_SECRET"),
+		logger:       slog.Default(),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// ExchangeToken exchanges an authorization code for tokens.
+func (c *HTTPClient) ExchangeToken(ctx context.Context, code, redirectURI, codeVerifier string) (*Tokens, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code_verifier", codeVerifier)
+
+	return c.requestTokens(ctx, form, "token exchange")
+}
+
+// RefreshToken exchanges a refresh token for a new set of tokens.
+// Twitter rotates the refresh token, so the returned one must be persisted.
+func (c *HTTPClient) RefreshToken(ctx context.Context, refreshToken string) (*Tokens, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("%w: no refresh token stored", ErrReauthRequired)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	tokens, err := c.requestTokens(ctx, form, "token refresh")
+	if err != nil {
+		return nil, err
+	}
+
+	// Defensive: keep the current refresh token if Twitter did not rotate it.
+	if tokens.RefreshToken == "" {
+		tokens.RefreshToken = refreshToken
+	}
+
+	return tokens, nil
+}
+
+func (c *HTTPClient) requestTokens(ctx context.Context, form url.Values, operation string) (*Tokens, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(c.clientID, c.clientSecret)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error(operation+" failed", "status", resp.StatusCode, "body", string(body))
+		apiErr := &APIError{StatusCode: resp.StatusCode, Message: string(body)}
+		// The grant itself was rejected: refreshing again will not help.
+		if resp.StatusCode == http.StatusBadRequest ||
+			resp.StatusCode == http.StatusUnauthorized ||
+			resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("%w: %v", ErrReauthRequired, apiErr)
+		}
+		return nil, apiErr
+	}
+
+	var tokens Tokens
+	if err := json.Unmarshal(body, &tokens); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &tokens, nil
+}
+
+// GetUserInfo fetches the profile of the authenticated user.
+func (c *HTTPClient) GetUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.userURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &APIError{StatusCode: resp.StatusCode, Message: string(body)}
+	}
+
+	var userResp userResponse
+	if err := json.Unmarshal(body, &userResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &userResp.Data, nil
+}
+
+// PostTweet posts a tweet as the authenticated user.
+func (c *HTTPClient) PostTweet(ctx context.Context, accessToken, text string) error {
+	jsonBody, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tweetURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return &APIError{StatusCode: resp.StatusCode, Message: string(body)}
+	}
+
+	return nil
+}
+
+// APIError represents a Twitter API error.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("twitter api error: %d - %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("twitter api error: %d", e.StatusCode)
+}
+
+// IsAPIError reports whether err is an APIError.
+func IsAPIError(err error) (*APIError, bool) {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr, true
+	}
+	return nil, false
+}

--- a/internal/twitter/client_test.go
+++ b/internal/twitter/client_test.go
@@ -1,0 +1,176 @@
+package twitter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshToken_Success(t *testing.T) {
+	var gotForm url.Values
+	var gotUser, gotPass string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotForm, _ = url.ParseQuery(string(body))
+		gotUser, gotPass, _ = r.BasicAuth()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Tokens{
+			TokenType:    "bearer",
+			ExpiresIn:    7200,
+			AccessToken:  "new-access",
+			RefreshToken: "new-refresh",
+			Scope:        "tweet.write offline.access",
+		})
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTokenURL(server.URL), WithCredentials("client-id", "client-secret"))
+	tokens, err := c.RefreshToken(context.Background(), "old-refresh")
+
+	require.NoError(t, err)
+	assert.Equal(t, "new-access", tokens.AccessToken)
+	assert.Equal(t, "new-refresh", tokens.RefreshToken)
+	assert.Equal(t, 7200, tokens.ExpiresIn)
+	assert.Equal(t, "refresh_token", gotForm.Get("grant_type"))
+	assert.Equal(t, "old-refresh", gotForm.Get("refresh_token"))
+	assert.Equal(t, "client-id", gotUser)
+	assert.Equal(t, "client-secret", gotPass)
+}
+
+func TestRefreshToken_KeepsCurrentRefreshTokenWhenNotRotated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(Tokens{ExpiresIn: 7200, AccessToken: "new-access"})
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTokenURL(server.URL))
+	tokens, err := c.RefreshToken(context.Background(), "old-refresh")
+
+	require.NoError(t, err)
+	assert.Equal(t, "old-refresh", tokens.RefreshToken)
+}
+
+func TestRefreshToken_InvalidGrantRequiresReauth(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+		}))
+
+		c := NewHTTPClient(WithTokenURL(server.URL))
+		_, err := c.RefreshToken(context.Background(), "revoked")
+
+		assert.ErrorIs(t, err, ErrReauthRequired, "status %d", status)
+		server.Close()
+	}
+}
+
+func TestRefreshToken_ServerErrorIsNotReauth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTokenURL(server.URL))
+	_, err := c.RefreshToken(context.Background(), "still-valid")
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrReauthRequired)
+	apiErr, ok := IsAPIError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
+}
+
+func TestRefreshToken_WithoutRefreshTokenRequiresReauth(t *testing.T) {
+	c := NewHTTPClient(WithTokenURL("http://127.0.0.1:0"))
+	_, err := c.RefreshToken(context.Background(), "")
+
+	assert.ErrorIs(t, err, ErrReauthRequired)
+}
+
+func TestExchangeToken(t *testing.T) {
+	var gotForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotForm, _ = url.ParseQuery(string(body))
+		_ = json.NewEncoder(w).Encode(Tokens{ExpiresIn: 7200, AccessToken: "access", RefreshToken: "refresh"})
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTokenURL(server.URL))
+	tokens, err := c.ExchangeToken(context.Background(), "code", "https://example.com/callback", "verifier")
+
+	require.NoError(t, err)
+	assert.Equal(t, "access", tokens.AccessToken)
+	assert.Equal(t, "authorization_code", gotForm.Get("grant_type"))
+	assert.Equal(t, "code", gotForm.Get("code"))
+	assert.Equal(t, "https://example.com/callback", gotForm.Get("redirect_uri"))
+	assert.Equal(t, "verifier", gotForm.Get("code_verifier"))
+}
+
+func TestPostTweet(t *testing.T) {
+	var gotBody map[string]string
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTweetURL(server.URL))
+	err := c.PostTweet(context.Background(), "access-token", "now playing")
+
+	require.NoError(t, err)
+	assert.Equal(t, "now playing", gotBody["text"])
+	assert.Equal(t, "Bearer access-token", gotAuth)
+}
+
+func TestPostTweet_UnauthorizedIsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Unauthorized"))
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTweetURL(server.URL))
+	err := c.PostTweet(context.Background(), "expired", "now playing")
+
+	apiErr, ok := IsAPIError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Error(), "Unauthorized")
+}
+
+func TestGetUserInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"id":"1","name":"Test","username":"test","profile_image_url":"https://example.com/a.jpg"}}`))
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithUserURL(server.URL))
+	user, err := c.GetUserInfo(context.Background(), "access-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "1", user.ID)
+	assert.Equal(t, "test", user.Username)
+	assert.Equal(t, "https://example.com/a.jpg", user.ProfileImageURL)
+}
+
+func TestIsAPIError_WrappedError(t *testing.T) {
+	wrapped := errors.Join(&APIError{StatusCode: 429}, errors.New("other"))
+	apiErr, ok := IsAPIError(wrapped)
+	require.True(t, ok)
+	assert.Equal(t, 429, apiErr.StatusCode)
+}

--- a/internal/twitter/client_test.go
+++ b/internal/twitter/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -61,10 +62,12 @@ func TestRefreshToken_KeepsCurrentRefreshTokenWhenNotRotated(t *testing.T) {
 }
 
 func TestRefreshToken_InvalidGrantRequiresReauth(t *testing.T) {
+	// invalid_grant is what a revoked or already-rotated refresh token comes
+	// back as, whichever status Twitter picks for it.
 	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden} {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(status)
-			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Value passed for the refresh token was invalid."}`))
 		}))
 
 		c := NewHTTPClient(WithTokenURL(server.URL))
@@ -73,6 +76,44 @@ func TestRefreshToken_InvalidGrantRequiresReauth(t *testing.T) {
 		assert.ErrorIs(t, err, ErrReauthRequired, "status %d", status)
 		server.Close()
 	}
+}
+
+func TestRefreshToken_MisconfigurationIsNotReauth(t *testing.T) {
+	// These share invalid_grant's status but are this application's problem:
+	// reconnecting would never fix them.
+	for _, code := range []string{"invalid_client", "invalid_request", "unauthorized_client", "unsupported_grant_type"} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, `{"error":%q}`, code)
+		}))
+
+		c := NewHTTPClient(WithTokenURL(server.URL))
+		_, err := c.RefreshToken(context.Background(), "still-valid")
+
+		require.Error(t, err, code)
+		assert.NotErrorIs(t, err, ErrReauthRequired, code)
+		apiErr, ok := IsAPIError(err)
+		require.True(t, ok, code)
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode, code)
+		server.Close()
+	}
+}
+
+func TestRefreshToken_NonJSONErrorIsNotReauth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Unauthorized"))
+	}))
+	defer server.Close()
+
+	c := NewHTTPClient(WithTokenURL(server.URL))
+	_, err := c.RefreshToken(context.Background(), "still-valid")
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrReauthRequired)
+	apiErr, ok := IsAPIError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
 }
 
 func TestRefreshToken_ServerErrorIsNotReauth(t *testing.T) {


### PR DESCRIPTION
## 問題

OAuth 2.0 PKCEで取得したTwitterのアクセストークンは約2時間で失効しますが、投稿処理は保存済みのアクセストークンをそのまま使っていました。有効期限を確認せず、401になっても更新も再試行もしません。そのため「連携直後は投稿できるが、約2時間後から401になる」状態でした。

`RefreshTwitterToken` は定義されていましたが呼び出し元がなく、更新結果をDBへ保存する処理もない実質的なデッドコードでした。

## 修正

- **`internal/twitter` パッケージを追加**
  トークンエンドポイント・`users/me`・ツイート作成のクライアント。`internal/spotify` と同じくエンドポイントをテスト用に差し替えられます。

- **投稿前にトークンを更新**
  有効期限切れ（および期限まで5分未満）なら投稿前にリフレッシュします。新しいアクセストークン・ローテーションされたリフレッシュトークン・新しい有効期限をすべてDBへ保存します。

- **401時に一度だけ更新・再試行**
  時刻判定をすり抜けた401（クロックスキュー、Twitter側での失効など）に備えて、一度だけ更新して再試行します。

- **同時投稿によるリフレッシュ競合の防止**
  `store.EnsureTwitterToken` が `SELECT ... FOR UPDATE` でユーザー行をロックした状態で更新するため、同時に走った投稿が互いのローテーション済みリフレッシュトークンを無効化することはありません。401再試行時は、他のリクエストが既に更新済みなら更新をスキップしてその結果を使います。

- **リクエストのキャンセルから切り離し**
  リフレッシュ中に呼び出し元が切断しても、ローテーション済みリフレッシュトークンを保存し損ねないようにしました（保存に失敗すると再連携が必要になるため）。

- **再連携が必要な場合の明示**
  リフレッシュトークンが使えない場合は `results.twitter` が `error: twitter token expired, reconnect required` になります。

- **OAuthコールバックも同じクライアントを使用**
  重複していたトークン交換処理とデッドコードの `RefreshTwitterToken` を削除しました。

## 挙動の変更（要確認）

`GET /api/post/:token` は、**実際に投稿を試みた投稿先がすべて失敗した場合に 502** を返すようになります。従来は `200` + `success:false` で、監視や呼び出し側から認証失敗が見落とされる状態でした。

- 再生中の曲がない場合: これまで通り `200`
- 未連携（投稿を試みていない）: これまで通り `200`

## テスト

Twitterの期限切れ・更新・再試行を検証するテストがなかったため追加しました。

- `internal/twitter`: リフレッシュ成功、リフレッシュトークン未ローテーション時の維持、`invalid_grant`（400/401/403）→再連携要求、5xx→再連携扱いにしない、コード交換、ツイート投稿、401の判定、`users/me`
- `internal/handler`: 有効期限判定、有効なトークンはそのまま使う、期限切れは更新して保存、401で一度だけ再試行、二度目の401は再試行しない、他リクエストが更新済みなら更新しない、再連携要求の伝播、429などは再試行しない

`go test -race ./...` / `go vet ./...` / `golangci-lint run ./...` はすべてパスします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)