### PR TITLE
fix(ci): Go のバージョンを go.mod と Dockerfile で必ず揃える

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,9 +108,49 @@ jobs:
       - name: Type check
         run: pnpm tsc -b
 
+  # go.mod の go directive と Dockerfile のビルド用 golang イメージがずれていると、
+  # golang イメージは GOTOOLCHAIN=local なので release の docker build が
+  # "go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)" で落ちる。
+  # test.yaml は setup-go で go.mod を見るだけなのでこのズレを検知できない。
+  # renovate 側でも 1 PR にまとめているが、片方の版が未公開だと片肺の PR になりうるので
+  # ここで最終的に止める。
+  go-version-guard:
+    name: Guard Go version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.3
+
+      - name: Check go.mod and Dockerfile agree on the Go version
+        run: |
+          set -euo pipefail
+          gomod_version="$(sed -n 's/^go \([0-9][0-9.]*\)[[:space:]]*$/\1/p' go.mod)"
+          image_version="$(sed -n 's|^FROM .*golang:\([0-9][0-9.]*\)-.*|\1|p' Dockerfile)"
+
+          if [ -z "$gomod_version" ]; then
+            echo "::error file=go.mod::go directive を読み取れませんでした"
+            exit 1
+          fi
+          if [ -z "$image_version" ]; then
+            echo "::error file=Dockerfile::golang ベースイメージのタグを読み取れませんでした"
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$image_version" | wc -l)" -ne 1 ]; then
+            echo "::error file=Dockerfile::golang ベースイメージが複数あります: $image_version"
+            exit 1
+          fi
+
+          echo "go.mod:     $gomod_version"
+          echo "Dockerfile: $image_version"
+
+          if [ "$gomod_version" != "$image_version" ]; then
+            echo "::error file=Dockerfile::Go のバージョンが go.mod ($gomod_version) と Dockerfile ($image_version) でずれています。両方揃えてください。"
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
-    needs: [test, lint, frontend-test, frontend-lint]
+    needs: [test, lint, frontend-test, frontend-lint, go-version-guard]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY frontend/ ./
 RUN pnpm build
 
 # Backend build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine3.23 AS build
 ARG TARGETOS
 ARG TARGETARCH
 ADD ./ ./

--- a/renovate.json5
+++ b/renovate.json5
@@ -43,17 +43,6 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/go\\.mod$/',
-      ],
-      matchStrings: [
-        'go (?<currentValue>\\d+\\.\\d+\\.\\d+)\\n',
-      ],
-      depNameTemplate: 'golang',
-      datasourceTemplate: 'golang-version',
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
         '/^charts/.+/values\\.yaml$/',
       ],
       matchStrings: [
@@ -108,15 +97,6 @@
       automerge: true,
     },
     {
-      matchDepNames: [
-        'golang',
-      ],
-      groupName: 'golang version',
-      commitMessageTopic: 'Go version',
-      semanticCommitType: 'fix',
-      automerge: true,
-    },
-    {
       matchManagers: [
         'npm',
       ],
@@ -129,6 +109,26 @@
         'gomod',
       ],
       commitMessageTopic: 'Go {{depName}}',
+      semanticCommitType: 'fix',
+      automerge: true,
+    },
+    // Go のバージョンは go.mod の go directive (gomod) と Dockerfile のビルド用
+    // ベースイメージ (dockerfile) の 2 箇所にある。別々の PR で上がると go.mod だけ
+    // 先に merge されて Dockerfile が 1 つ前のまま取り残され、golang イメージは
+    // GOTOOLCHAIN=local なので release の docker build が
+    // "go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)" で落ちる。
+    // 同じ groupName にまとめて必ず 1 PR で両方上げる。
+    // matchManagers: ['gomod'] のルールより後に置くこと (後勝ちで上書きされるため)。
+    // 片方の版が未公開で PR が go.mod だけになる可能性は残るので、
+    // 最終的な担保は test.yaml の go-version-guard が行う。
+    {
+      matchDepNames: [
+        'go',
+        'toolchain',
+        'golang',
+      ],
+      groupName: 'golang version',
+      commitMessageTopic: 'Go version',
       semanticCommitType: 'fix',
       automerge: true,
     },


### PR DESCRIPTION
## 何が起きたか

#348 / #347 で `go.mod` が 1.26.7 になった一方、Dockerfile のビルド用ベースイメージが `golang:1.26.6-alpine3.23` のまま取り残され、release の docker build が失敗していた。

```
go: go.mod requires go >= 1.26.7 (running go 1.26.6; GOTOOLCHAIN=local)
```

golang イメージは `GOTOOLCHAIN=local` なのでツールチェーンの自動取得も効かない。
`test.yaml` は setup-go で `go.mod` を読むだけなので、このズレを CI で検知できなかった。

## 直したこと

### 1. 応急処置: Dockerfile を 1.26.7 に
release を復旧させる。

### 2. 根本原因: renovate が Go の版を一括で上げていなかった

Go の版はリポジトリ内に 3 経路あった。

| 経路 | manager | depName | 出ていた PR |
|---|---|---|---|
| `go.mod` の go directive | `gomod` | `go` | #347 |
| `go.mod` (custom regex) | `custom.regex` | `golang` | #348 |
| Dockerfile のベースイメージ | `dockerfile` | `golang` | 出ていない |

- **custom regex manager を削除。** `gomod` manager と完全に重複しており、毎回まったく同じ差分の PR が 2 本出ていた (#347/#348、#345/#346)。`go.mod` の更新は `gomod` manager だけで足りる。
- **`go` / `toolchain` / `golang` を `groupName: 'golang version'` にまとめた。** これで `go.mod` と Dockerfile が 1 つの PR で同時に上がる。既存の golang ルールは `matchDepNames: ['golang']` だったため depName `go` を拾えず、かつ `matchManagers: ['gomod']` ルールより前にあって後勝ちで上書きされていた。新しいルールは gomod ルールの**後ろ**に置いている。

### 3. 担保: `go-version-guard` を test.yaml に追加

renovate 側でまとめても、golang の docker タグが未公開のタイミングでは `go.mod` だけの片肺 PR になりうる。`go.mod` と Dockerfile の Go の版がずれていたら PR を落とすジョブを足し、`build` の `needs` に入れた。automerge を信頼するための最終的な担保。

## 検証

- guard スクリプトを手元で実行し、現状 (1.26.7 / 1.26.7) で pass、今回の事故の再現 (go.mod 1.26.7 / image 1.26.6) で exit 1 になることを確認
- `renovate-config-validator` (renovate 44.46.6) で config が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)